### PR TITLE
Missing autoconfigure option

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,3 +1,4 @@
 services:
     Boulzy\ManagerBundle\Collection\ManagerCollection:
         public: true
+        autoconfigure: true


### PR DESCRIPTION
Without this option, your CompilerPass don't see the ManagerCollection